### PR TITLE
Remove useless suggestions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,14 +23,6 @@
         "ruflin/elastica": "^1.3 || ^2.0 || ^3.0 || ^5.0 || ^6.0",
         "solarium/solarium": "^2.3 || ^3.0 || ^4.0 || ^5.0"
     },
-    "suggest": {
-        "doctrine/collections": "To use the Doctrine Collection and Selectable adapter.",
-        "doctrine/dbal": "To use the Doctrine DBAL adapters.",
-        "doctrine/mongodb-odm": "To use the Doctrine MongoDB ODM Adapter.",
-        "doctrine/orm": "To use the Doctrine ORM Adapter.",
-        "doctrine/phpcr-odm": "To use the Doctrine PHPCR ODM Adapter.",
-        "solarium/solarium": "To use the SolariumAdapter."
-    },
     "autoload": {
         "psr-4": {
             "Pagerfanta\\": "src/"


### PR DESCRIPTION
Suggestions are meant to link to packages which can enhance the features of a package.

None of these suggestions are about enhancing features of Pagerfanta. If the project does not already use one of these packages (which means the suggestions is already hidden by composer), there is no reason to use the corresponding adapter.