### PR TITLE
Add interfaces for a route generator and a route generator factory

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -5,4 +5,5 @@
 - [Available Adapters](/open-source/packages/pagerfanta/docs/2.x/adapters)
 - [Views](/open-source/packages/pagerfanta/docs/2.x/views)
 - [Templates](/open-source/packages/pagerfanta/docs/2.x/templates)
+- [Route Generator](/open-source/packages/pagerfanta/docs/2.x/route-generator)
 - [Framework Integrations](/open-source/packages/pagerfanta/docs/2.x/framework-integrations)

--- a/docs/route-generator.md
+++ b/docs/route-generator.md
@@ -1,0 +1,62 @@
+# Route Generator
+
+Pagerfanta uses a route generator as a mechanism for building URLs to different pages in a paginated list.
+
+A route generator is any callable which accepts a single `$page` parameter (the page to build the URL for) and returns the URL for the page being requested.
+
+```php
+$routeGenerator = function (int $page): string {
+    return 'http://localhost/blog?page=' . $page;
+};
+```
+
+## Generator Interface
+
+<div class="docs-note docs-note--new-feature">This feature was introduced in Pagerfanta 2.4.</div>
+
+It is recommended that route generators are classes which implement `Pagerfanta\RouteGenerator\RouteGeneratorInterface`.
+
+## Generator Factory
+
+<div class="docs-note docs-note--new-feature">This feature was introduced in Pagerfanta 2.4.</div>
+
+Often, it is necessary to configure a route generator based on runtime information (such as data from the current request). The `Pagerfanta\RouteGenerator\RouteGeneratorFactoryInterface` defines a class which can assist in building your route generators.
+
+A basic example of how these factories can be used is with a Twig extension when rendering your pagination list.
+
+```php
+<?php
+
+namespace App\Twig;
+
+use Pagerfanta\Pagerfanta;
+use Pagerfanta\RouteGenerator\RouteGeneratorFactoryInterface;
+use Pagerfanta\RouteGenerator\RouteGeneratorInterface;
+use Pagerfanta\View\ViewFactoryInterface;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+final class PagerfantaExtension extends AbstractExtension
+{
+    private RouteGeneratorFactoryInterface $routeGeneratorFactory;
+    private ViewFactoryInterface $viewFactory;
+
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction('pagerfanta', [$this, 'renderPagerfanta'], ['is_safe' => ['html']]),
+        ];
+    }
+
+    public function renderPagerfanta(Pagerfanta $pagerfanta, string $view, array $options = []): string
+    {
+        return $this->viewFactory->get($view)
+            ->render($pagerfanta, $this->createRouteGenerator($options), $options);
+    }
+
+    private function createRouteGenerator(array $options = []): RouteGeneratorInterface
+    {
+        return $this->routeGeneratorFactory->create($options);
+    }
+}
+```

--- a/src/RouteGenerator/RouteGeneratorFactoryInterface.php
+++ b/src/RouteGenerator/RouteGeneratorFactoryInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Pagerfanta\RouteGenerator;
+
+interface RouteGeneratorFactoryInterface
+{
+    public function create(array $options = []): RouteGeneratorInterface;
+}

--- a/src/RouteGenerator/RouteGeneratorInterface.php
+++ b/src/RouteGenerator/RouteGeneratorInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Pagerfanta\RouteGenerator;
+
+interface RouteGeneratorInterface
+{
+    /**
+     * Generates the URL for a page item in a paginator
+     *
+     * @return string The page URL
+     */
+    public function __invoke(int $page): string;
+}


### PR DESCRIPTION
Closes #8

In the Symfony bundle I added interfaces representing a route generator and a factory class which creates a route generator, and I think these are good additions to the core Pagerfanta API.

When working with `Pagerfanta\View\ViewInterface` instances to render out pagination, you have to supply a `Pagerfanta\Pagerfanta` instance with the pagination data and a route generator which is responsible for building the URLs for the pagination list.  How you build those generators isn't really well defined though, and right now the interface has a very loosely documented callable as its requirement.  Then, for the longest time in the Symfony bundle, you couldn't really customize the route generator without overloading the entirety of the Twig integration because all of the logic was built into the Twig extension there.

Part of what I want to do with the library (well, this moreso affects framework integrations like Symfony than the library itself) is making it more API friendly to support paginated datasets and not just rendering out a pagination bar on a HTML document.  The route generator definition works well for that context as well, but I don't want to encourage passing random callables around as a way of handling the construction of paginated URLs (i.e. if someone wanted to add a `Link` header to a response and they're using the main `Pagerfanta\Pagerfanta` class already, it wouldn't be hard to do something like `$routeGenerator($pagerfanta->getNextPage());`).

By defining an interface for a route generator builder/factory, this allows later features like moving the full Twig integration as suggested in #5 to the "core" library without hardcoding the route generating logic to a single implementation (which, in the case of the Symfony bundle, relies upon `symfony/http-foundation` and `symfony/routing`).

And, by defining an interface for a route generator, we make it much more clear how a generator should look/function.  Right now the API only suggests it's a callable and you have to dig through the documentation to find the required signature for the callable, making it an interface makes it pretty clear what the API is expecting.  For maximum B/C, the route generator interface only requires an `__invoke()` method meaning the instance will fulfill the existing callable checks.

### TODO

- [x] Write new docs page describing the generators (https://github.com/BabDev/BabDevPagerfantaBundle/blob/2.x/docs/generating-paginated-routes.md very briefly covers them for the bundle)