### PR TITLE
Fix deprecation warning

### DIFF
--- a/lib/Core/Exception/InvalidArgumentException.php
+++ b/lib/Core/Exception/InvalidArgumentException.php
@@ -2,6 +2,6 @@
 
 namespace Pagerfanta\Exception;
 
-class InvalidArgumentException extends \InvalidArgumentException implements Exception
+class InvalidArgumentException extends \InvalidArgumentException implements PagerfantaException
 {
 }

--- a/lib/Core/Exception/LogicException.php
+++ b/lib/Core/Exception/LogicException.php
@@ -2,6 +2,6 @@
 
 namespace Pagerfanta\Exception;
 
-class LogicException extends \LogicException implements Exception
+class LogicException extends \LogicException implements PagerfantaException
 {
 }

--- a/lib/Core/Exception/OutOfBoundsException.php
+++ b/lib/Core/Exception/OutOfBoundsException.php
@@ -2,6 +2,6 @@
 
 namespace Pagerfanta\Exception;
 
-class OutOfBoundsException extends \OutOfBoundsException implements Exception
+class OutOfBoundsException extends \OutOfBoundsException implements PagerfantaException
 {
 }

--- a/lib/Core/Exception/RuntimeException.php
+++ b/lib/Core/Exception/RuntimeException.php
@@ -2,6 +2,6 @@
 
 namespace Pagerfanta\Exception;
 
-class RuntimeException extends \RuntimeException implements Exception
+class RuntimeException extends \RuntimeException implements PagerfantaException
 {
 }


### PR DESCRIPTION
Because of this lines, it will be thrown deprecation warnings no matter if you implements the "Exception" interface. This fix the warnings.
But i am not sure if this are a breaking change for those who use this bundle. For me this works.