### PR TITLE
Add a docblock for ViewInterface::render $options argument

### DIFF
--- a/lib/Core/View/ViewInterface.php
+++ b/lib/Core/View/ViewInterface.php
@@ -12,6 +12,7 @@ interface ViewInterface
      * The route generator can be any callable to generate the routes receiving the page number as first and unique argument.
      *
      * @param callable $routeGenerator
+     * @param array<string, mixed> $options
      *
      * @return string
      */


### PR DESCRIPTION
Hi,

this is a small docblock change that solves PHPStan issue in implementing code similar to this:

```
Method App\Pagerfanta\View\CollectionView::render() has parameter $options with no value type specified in iterable type array.
```