### PR TITLE
Add generics notation to Pagerfanta class

### DIFF
--- a/lib/Core/Pagerfanta.php
+++ b/lib/Core/Pagerfanta.php
@@ -14,6 +14,9 @@ use Pagerfanta\Exception\NotIntegerMaxPerPageException;
 use Pagerfanta\Exception\OutOfBoundsException;
 use Pagerfanta\Exception\OutOfRangeCurrentPageException;
 
+/**
+ * @implements \IteratorAggregate<mixed>
+ */
 class Pagerfanta implements \Countable, \IteratorAggregate, \JsonSerializable, PagerfantaInterface
 {
     /**


### PR DESCRIPTION
This solves PHPStan issues in 3rd party code similar to this:

```
  32     Method App\CollectionPager::renderCollectionPager() has parameter $pagerfanta with no value type specified in iterable type                        
         Pagerfanta\Pagerfanta.                                                                                                                                                                                    
         💡 See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type
```

On merge to 3.x, this notation should be moved to `PagerfantaInterface`