### PR TITLE
add Doctrine MongoDB ODM Aggregation adapter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     "conflict": {
         "doctrine/collections": "<1.6",
         "doctrine/dbal": "<2.12",
-        "doctrine/mongodb-odm": "<2.0",
+        "doctrine/mongodb-odm": "<2.2.2",
         "doctrine/orm": "<2.8",
         "doctrine/phpcr-odm": "<1.5",
         "ruflin/elastica": "<6.0",

--- a/lib/Adapter/Doctrine/MongoDBODM/AggregationAdapter.php
+++ b/lib/Adapter/Doctrine/MongoDBODM/AggregationAdapter.php
@@ -1,0 +1,42 @@
+<?php declare(strict_types=1);
+
+namespace Pagerfanta\Doctrine\MongoDBODM;
+
+use Doctrine\ODM\MongoDB\Aggregation\Builder;
+use Pagerfanta\Adapter\AdapterInterface;
+
+/**
+ * Adapter which calculates pagination from a Doctrine MongoDB ODM Aggregation Builder.
+ */
+class AggregationAdapter implements AdapterInterface
+{
+    private Builder $aggregationBuilder;
+
+    public function __construct(Builder $aggregationBuilder)
+    {
+        $this->aggregationBuilder = $aggregationBuilder;
+    }
+
+    public function getNbResults(): int
+    {
+        $aggregationBuilder = clone $this->aggregationBuilder;
+
+        return $aggregationBuilder
+            ->hydrate(null)
+            ->count('numResults')
+            ->getAggregation()
+            ->getIterator()
+            ->toArray()[0]['numResults'] ?? 0;
+    }
+
+    public function getSlice(int $offset, int $length): iterable
+    {
+        $aggregationBuilder = clone $this->aggregationBuilder;
+
+        return $aggregationBuilder
+            ->skip($offset)
+            ->limit($length)
+            ->getAggregation()
+            ->getIterator();
+    }
+}

--- a/lib/Adapter/Doctrine/MongoDBODM/Tests/AggregationAdapterTest.php
+++ b/lib/Adapter/Doctrine/MongoDBODM/Tests/AggregationAdapterTest.php
@@ -1,0 +1,101 @@
+<?php declare(strict_types=1);
+
+namespace Pagerfanta\Doctrine\MongoDBODM\Tests;
+
+use Doctrine\ODM\MongoDB\Aggregation\Aggregation;
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Count;
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Skip;
+use Doctrine\ODM\MongoDB\DocumentManager;
+use Doctrine\ODM\MongoDB\Aggregation\Builder;
+use Doctrine\ODM\MongoDB\Iterator\Iterator;
+use Pagerfanta\Doctrine\MongoDBODM\AggregationAdapter;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+final class AggregationAdapterTest extends TestCase
+{
+    /**
+     * @var MockObject&Builder
+     */
+    private $aggregationBuilder;
+
+    /**
+     * @var AggregationAdapter
+     */
+    private $adapter;
+
+    public static function setUpBeforeClass(): void
+    {
+        if (!class_exists(DocumentManager::class)) {
+            self::markTestSkipped('doctrine/mongodb-odm is not installed');
+        }
+    }
+
+    protected function setUp(): void
+    {
+        $this->aggregationBuilder = $this->createMock(Builder::class);
+
+        $this->adapter = new AggregationAdapter($this->aggregationBuilder);
+    }
+
+    public function testGetNbResultsShouldResetHydrationAndAddCountStage(): void
+    {
+        $aggregation = $this->createMock(Aggregation::class);
+        $resultIterator = $this->createMock(Iterator::class);
+        $countStage = $this->createMock(Count::class);
+
+        $countStage->expects(self::once())
+            ->method('getAggregation')
+            ->willReturn($aggregation);
+
+        $resultIterator->expects(self::once())
+            ->method('toArray')
+            ->willReturn([['numResults' => 110]]);
+
+        $aggregation->expects(self::once())
+            ->method('getIterator')
+            ->willReturn($resultIterator);
+
+        $this->aggregationBuilder->expects(self::once())
+            ->method('hydrate')
+            ->with(null)
+            ->willReturnSelf();
+
+        $this->aggregationBuilder->expects(self::once())
+            ->method('count')
+            ->with('numResults')
+            ->willReturn($countStage);
+
+        $this->assertSame(110, $this->adapter->getNbResults());
+    }
+
+    public function testGetSlice(): void
+    {
+        $offset = 10;
+        $length = 15;
+        $slice = $this->createMock(Iterator::class);
+
+        $aggregation = $this->createMock(Aggregation::class);
+        $skipStage = $this->createMock(Skip::class);
+
+        $skipStage->expects(self::once())
+            ->method('limit')
+            ->with($length)
+            ->willReturn($this->aggregationBuilder);
+
+        $this->aggregationBuilder->expects(self::once())
+            ->method('getAggregation')
+            ->willReturn($aggregation);
+
+        $aggregation->expects(self::once())
+            ->method('getIterator')
+            ->willReturn($slice);
+
+        $this->aggregationBuilder->expects(self::once())
+            ->method('skip')
+            ->with($offset)
+            ->willReturn($skipStage);
+
+        $this->assertSame($slice, $this->adapter->getSlice($offset, $length));
+    }
+}

--- a/lib/Adapter/Doctrine/MongoDBODM/composer.json
+++ b/lib/Adapter/Doctrine/MongoDBODM/composer.json
@@ -6,7 +6,7 @@
     "license": "MIT",
     "require": {
         "php": "^7.4 || ^8.0",
-        "doctrine/mongodb-odm": "^2.0",
+        "doctrine/mongodb-odm": "^2.2.2",
         "pagerfanta/core": "^3.0",
         "symfony/deprecation-contracts": "^2.1"
     },


### PR DESCRIPTION
This PR adds Doctrine MongoDB ODM Aggregation adapter.
Please note it requires at least v2.2.2 which enables to reset hydration parameter (for number of results calculation): https://github.com/doctrine/mongodb-odm/releases/tag/2.2.2