### PR TITLE
Add #[\ReturnTypeWillChange] attribute to disable PHP 8.1 deprecation notices

### DIFF
--- a/lib/Core/Pagerfanta.php
+++ b/lib/Core/Pagerfanta.php
@@ -483,6 +483,7 @@ class Pagerfanta implements \Countable, \IteratorAggregate, \JsonSerializable, P
     /**
      * @return int
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return $this->getNbResults();
@@ -491,6 +492,7 @@ class Pagerfanta implements \Countable, \IteratorAggregate, \JsonSerializable, P
     /**
      * @return \Traversable<array-key, T>
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         $results = $this->getCurrentPageResults();
@@ -513,6 +515,7 @@ class Pagerfanta implements \Countable, \IteratorAggregate, \JsonSerializable, P
     /**
      * @return iterable
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         $results = $this->getCurrentPageResults();


### PR DESCRIPTION
PHP 8.1 adds notices like these:

```
Deprecated: Return type of Pagerfanta\Pagerfanta::count()
should either be compatible with Countable::count(): int, or the #[\ReturnTypeWillChange]
attribute should be used to temporarily suppress the notice
```