### PR TITLE
add TransformingAdapter

### DIFF
--- a/lib/Core/Adapter/TransformingAdapter.php
+++ b/lib/Core/Adapter/TransformingAdapter.php
@@ -1,0 +1,57 @@
+<?php declare(strict_types=1);
+
+namespace Pagerfanta\Adapter;
+
+/**
+ * Adapter which transforms the result of other adapter.
+ *
+ * @template T
+ * @template Transformed
+ * @implements AdapterInterface<Transformed>
+ */
+class TransformingAdapter implements AdapterInterface
+{
+    /**
+     * @var AdapterInterface<T>
+     */
+    private $adapter;
+
+    /**
+     * @var callable
+     * @phpstan-var callable(T, array-key): Transformed
+     */
+    private $transformer;
+
+    /**
+     * @phpstan-param AdapterInterface<T>                 $adapter
+     * @phpstan-param callable(T, array-key): Transformed $transformer
+     */
+    public function __construct(AdapterInterface $adapter, callable $transformer)
+    {
+        $this->adapter = $adapter;
+        $this->transformer = $transformer;
+    }
+
+    /**
+     * @phpstan-return int<0, max>
+     */
+    public function getNbResults(): int
+    {
+        return $this->adapter->getNbResults();
+    }
+
+    /**
+     * @phpstan-param int<0, max> $offset
+     * @phpstan-param int<0, max> $length
+     *
+     * @return iterable<array-key, Transformed>
+     */
+    public function getSlice(int $offset, int $length): iterable
+    {
+        $transformer = $this->transformer;
+
+        foreach ($this->adapter->getSlice($offset, $length) as $key => $item) {
+            yield $transformer($item, $key);
+        }
+    }
+}

--- a/lib/Core/Tests/Adapter/TransformingAdapterTest.php
+++ b/lib/Core/Tests/Adapter/TransformingAdapterTest.php
@@ -1,0 +1,52 @@
+<?php declare(strict_types=1);
+
+namespace Pagerfanta\Tests\Adapter;
+
+use Pagerfanta\Adapter\ArrayAdapter;
+use Pagerfanta\Adapter\TransformingAdapter;
+use PHPUnit\Framework\TestCase;
+
+final class TransformingAdapterTest extends TestCase
+{
+    /**
+     * @var int[]
+     * @phpstan-var array<int<1, 100>>
+     */
+    private $array;
+
+    /**
+     * @var TransformingAdapter<int, string>
+     * @phpstan-var TransformingAdapter<int<1, 100>, string>
+     */
+    private $adapter;
+
+    protected function setUp(): void
+    {
+        $this->array = range(1, 100);
+        $this->adapter = new TransformingAdapter(new ArrayAdapter($this->array), function (int $item, int $key) {
+            return sprintf('%s => %s', $key, $item);
+        });
+    }
+
+    public function testAdapterReturnsNumberOfItemsInArray(): void
+    {
+        $this->assertSame(\count($this->array), $this->adapter->getNbResults());
+    }
+
+    public function testGetSlice(): void
+    {
+        $this->assertSame(['0 => 4', '1 => 5'], [...$this->adapter->getSlice(3, 2)]);
+    }
+
+    public function testCreateFromInvokable(): void
+    {
+        $this->adapter = new TransformingAdapter(new ArrayAdapter($this->array), new class {
+            public function __invoke(int $item, int $key): string
+            {
+                return sprintf('%s', $item - 100);
+            }
+        });
+
+        $this->assertSame(['-89', '-88', '-87', '-86', '-85'], [...$this->adapter->getSlice(10, 5)]);
+    }
+}


### PR DESCRIPTION
This PR adds a new core adapter: `TransformingAdapter`, allowing users to transform data from the inner adapter passed in constructor.

This is very useful when presenting the data from database as DTOs in the Pagerfanta instance.

The transforming callback accepts both current item and key as parameters and return the transformed object.
PHPStan annotations ensure type safety on all stages.