### PR TITLE
Mark generic interfaces as being covariant

### DIFF
--- a/lib/Core/Adapter/AdapterInterface.php
+++ b/lib/Core/Adapter/AdapterInterface.php
@@ -3,7 +3,7 @@
 namespace Pagerfanta\Adapter;
 
 /**
- * @template T
+ * @template-covariant T
  */
 interface AdapterInterface
 {

--- a/lib/Core/PagerfantaInterface.php
+++ b/lib/Core/PagerfantaInterface.php
@@ -10,7 +10,7 @@ use Pagerfanta\Exception\LogicException;
 use Pagerfanta\Exception\OutOfRangeCurrentPageException;
 
 /**
- * @template T
+ * @template-covariant T
  * @extends \IteratorAggregate<T>
  */
 interface PagerfantaInterface extends \Countable, \IteratorAggregate


### PR DESCRIPTION
This makes them easier to use when writing a method that can accept any data inside the PagerfantaInterface argument. And the interface are only using the template type in covariant positions.