### PR TITLE
feature : Auto Paging Iterator

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -183,3 +183,24 @@ $pagerfanta = new Pagerfanta(new NullAdapter(30));
 
 $pagerfanta->getAdapter(); // Will return the NullAdapter instance given
 ```
+
+## Auto-pagination
+
+If you want to iterate through all pages results step by step without having to load the whole result into memory at once (to avoid extreme memory consumption when batch processing for example), you can get an iterator with autoPagingIterator method on the `Pagerfanta` instance.
+
+```php
+<?php
+
+use Pagerfanta\Adapter\QueryAdapter;
+use Pagerfanta\Pagerfanta;
+
+$pagerfanta = new Pagerfanta(new QueryAdapter($queryBuilder, $countQueryBuilderModifier));
+$pagerfanta->setMaxPerPage(10);
+
+$iterator = $pagerfanta->autoPagingIterator();
+
+foreach ($iterator as $item) {
+  // Iterate over all query results without load them into memory, or manually manage getCurrentPageResults(), hasNextPage() and setCurrentPage()
+}
+
+```

--- a/lib/Core/Pagerfanta.php
+++ b/lib/Core/Pagerfanta.php
@@ -2,6 +2,7 @@
 
 namespace Pagerfanta;
 
+use Generator;
 use Pagerfanta\Adapter\AdapterInterface;
 use Pagerfanta\Exception\LessThan1CurrentPageException;
 use Pagerfanta\Exception\LessThan1MaxPagesException;
@@ -448,5 +449,24 @@ class Pagerfanta implements PagerfantaInterface, \JsonSerializable
         }
 
         return (int) ceil($position / $this->getMaxPerPage());
+    }
+
+    /**
+     * Helper to iterate through all pages results step by step without having to load the whole result into memory at once.
+     * Avoid extreme memory consumption when batch processing over all pagination results.
+     */
+    public function autoPagingIterator(): Generator
+    {
+        while (true) {
+            foreach ($this->getCurrentPageResults() as $item) {
+                yield $item;
+            }
+
+            if (!$this->hasNextPage()) {
+                break;
+            }
+
+            $this->setCurrentPage($this->getNextPage());
+        }
     }
 }

--- a/lib/Core/PagerfantaInterface.php
+++ b/lib/Core/PagerfantaInterface.php
@@ -13,6 +13,8 @@ use Pagerfanta\Exception\OutOfRangeCurrentPageException;
  * @template-covariant T
  *
  * @extends \IteratorAggregate<T>
+ *
+ * @method Generator autoPagingIterator()
  */
 interface PagerfantaInterface extends \Countable, \IteratorAggregate
 {

--- a/lib/Core/Tests/PagerfantaTest.php
+++ b/lib/Core/Tests/PagerfantaTest.php
@@ -582,10 +582,17 @@ final class PagerfantaTest extends TestCase
         $this->adapter->expects($matcher)
             ->method('getSlice')
             ->willReturnCallback(function (int $offset, int $length) use ($matcher) {
-                match ($matcher->numberOfInvocations()) {
-                    1 => $this->assertEquals($offset, 0) && $this->assertEquals($length, 2),
-                    2 => $this->assertEquals($offset, 2) && $this->assertEquals($length, 2),
-                };
+                if($matcher->numberOfInvocations() === 1) {
+                    $this->assertEquals($offset, 0);
+                    $this->assertEquals($length, 2);
+                }
+                else if($matcher->numberOfInvocations() === 2) {
+                    $this->assertEquals($offset, 2);
+                    $this->assertEquals($length, 2);
+                }
+                else {
+                    throw new \LogicException();
+                }
             })
             ->willReturnOnConsecutiveCalls(
                 [


### PR DESCRIPTION
Add helper method to iterate through all pages results step by step without having to load the whole result into memory at once.

Avoid extreme memory consumption when batch processing over all pagination results.

Example :
```php
$paginator = new Pagerfanta(new RemoteApiAdapter($api_filters, ...));

foreach($pagerfanta->autoPagingIterator() as $item) {
    // do things
}
```

see for details : https://github.com/BabDev/Pagerfanta/issues/47

Do I need to add the method signature to PagerFantaInterface ? (add BC, and require a major version to implement autoPagingIterator)