### PR TITLE
Update default.html.twig and add page twig variable where missing

### DIFF
--- a/lib/Twig/templates/default.html.twig
+++ b/lib/Twig/templates/default.html.twig
@@ -8,6 +8,7 @@
     {# Previous Page Link #}
     {%- if pagerfanta.hasPreviousPage() -%}
         {%- set path = route_generator.route(pagerfanta.getPreviousPage()) -%}
+        {%- set page = pagerfanta.getPreviousPage() -%}
         {{- block('previous_page_link') -}}
     {%- else -%}
         {{- block('previous_page_link_disabled') -}}
@@ -64,6 +65,7 @@
     {# Next Page Link #}
     {%- if pagerfanta.hasNextPage() -%}
         {%- set path = route_generator.route(pagerfanta.getNextPage()) -%}
+        {%- set page = pagerfanta.getNextPage() -%}
         {{- block('next_page_link') -}}
     {%- else -%}
         {{- block('next_page_link_disabled') -}}


### PR DESCRIPTION
So I was playing around with symfony/ux-live-components and modified a page with a pagerfanta grid to display some infos.

the only changs needed was to overwrite the template for the links. 
but unfortunatly the pager block doesnt have the `page` variable set in next/previous links. 
it would not hurt to have them in. 

```
{%- extends '@Pagerfanta/twitter_bootstrap5.html.twig' -%}

{%- block page_link -%}
    <li class="page-item"><a class="page-link" data-action="live#update" data-value="{{ page }}" data-model="page">{{- page -}}</a></li>
{%- endblock page_link -%}

{%- block previous_page_link -%}
    <li class="page-item"><a class="page-link"  data-action="live#update" data-value="{{ page }}" data-model="page" rel="prev">{{- block('previous_page_message') -}}</a></li>
{%- endblock previous_page_link -%}

{%- block next_page_link -%}
    <li class="page-item"><a class="page-link"  data-action="live#update" data-value="{{ page }}" data-model="page" rel="next">{{- block('next_page_message') -}}</a></li>
{%- endblock next_page_link -%}
```

For reference if someone want to try this:

```
#[AsLiveComponent('candidates')]
class CandidatesComponent
{
    use DefaultActionTrait;


    #[LiveProp(writable: true)]
    public int $page = 1;

    #[LiveProp()]
    public ?Pagerfanta $pagerfanta = null;


    public function getCandidates(): Collection|iterable
    {
        $queryBuilder = $this->getCandidatesQueryBuilder();
        $this->pagerfanta = new Pagerfanta(new QueryAdapter($queryBuilder));
        $this->pagerfanta->setCurrentPage($this->page);

        return $this->pagerfanta->getCurrentPageResults();
    }
}
```
```
<table>
            {% for candidate in this.candidates %}
               // print data
            {% endfor %}
</table>
{{ pagerfanta(this.pagerfanta, {'omitFirstPage': true }) }}
```

```
