### PR TITLE
Fix Doctrine's `Criteria::setFirstResult()` method usage deprecation

### DIFF
--- a/lib/Adapter/Doctrine/Collections/SelectableAdapter.php
+++ b/lib/Adapter/Doctrine/Collections/SelectableAdapter.php
@@ -29,7 +29,7 @@ class SelectableAdapter implements AdapterInterface
      */
     public function getNbResults(): int
     {
-        return $this->selectable->matching($this->createCriteria(null, null))->count();
+        return $this->selectable->matching($this->createCriteria(0, null))->count();
     }
 
     /**
@@ -44,10 +44,10 @@ class SelectableAdapter implements AdapterInterface
     }
 
     /**
-     * @phpstan-param int<0, max>|null $firstResult
+     * @phpstan-param int<0, max> $firstResult
      * @phpstan-param int<0, max>|null $maxResult
      */
-    private function createCriteria(?int $firstResult, ?int $maxResult): Criteria
+    private function createCriteria(int $firstResult, ?int $maxResult): Criteria
     {
         $criteria = clone $this->criteria;
         $criteria->setFirstResult($firstResult);


### PR DESCRIPTION
Fixes deprecation:
```
Passing null to Doctrine\Common\Collections\Criteria::setFirstResult() is deprecated, pass 0 instead.
```

Deprecation info: https://github.com/doctrine/collections/pull/311