### PR TITLE
Add an EmptyAdapter

### DIFF
--- a/lib/Core/Adapter/EmptyAdapter.php
+++ b/lib/Core/Adapter/EmptyAdapter.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types=1);
+
+namespace Pagerfanta\Adapter;
+
+/**
+ * An adapter that is always empty.
+ *
+ * @template-implements AdapterInterface<never>
+ */
+class EmptyAdapter implements AdapterInterface
+{
+    public function getNbResults(): int
+    {
+        return 0;
+    }
+
+    public function getSlice(int $offset, int $length): iterable
+    {
+        return [];
+    }
+}

--- a/lib/Core/Tests/Adapter/EmptyAdapterTest.php
+++ b/lib/Core/Tests/Adapter/EmptyAdapterTest.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types=1);
+
+namespace Adapter;
+
+use Pagerfanta\Adapter\EmptyAdapter;
+use PHPUnit\Framework\TestCase;
+
+final class EmptyAdapterTest extends TestCase
+{
+    public function testGetNbResults(): void
+    {
+        $adapter = new EmptyAdapter();
+
+        self::assertSame(0, $adapter->getNbResults());
+    }
+
+    public function testGetSliceShouldReturnAnEmptyArray(): void
+    {
+        $adapter = new EmptyAdapter();
+
+        self::assertSame([], $adapter->getSlice(10, 5));
+    }
+}


### PR DESCRIPTION
Unlike the NullAdapter, this adapter is always empty instead of allowing it to paginate an array of null values. Thanks to that, its generic type can fullfil types like `AdapterInterface<Foo>` with a non-nullable `Foo` type.

See https://phpstan.org/r/ada3d136-11fa-43f2-a5dc-dd282f008b3e for the difference it makes for phpstan and https://psalm.dev/r/cb09185906 for Psalm.

This EmptyAdapter is mostly meant to be used for conditional returns, where another branch of the execution would return a different adapter implementation (for instance to skip executing a DB query entirely when you know that the parameters you deal with cannot produce any results because they would execute a query with `WHERE true = false`).