### PR TITLE
Add more precise types for ElasticaAdapter

### DIFF
--- a/lib/Adapter/Elastica/ElasticaAdapter.php
+++ b/lib/Adapter/Elastica/ElasticaAdapter.php
@@ -3,6 +3,7 @@
 namespace Pagerfanta\Elastica;
 
 use Elastica\Query;
+use Elastica\Result;
 use Elastica\ResultSet;
 use Elastica\SearchableInterface;
 use Pagerfanta\Adapter\AdapterInterface;
@@ -11,9 +12,7 @@ use Pagerfanta\Exception\NotValidResultCountException;
 /**
  * Adapter which calculates pagination from an Elastica Query.
  *
- * @template T
- *
- * @implements AdapterInterface<T>
+ * @implements AdapterInterface<Result>
  */
 class ElasticaAdapter implements AdapterInterface
 {
@@ -70,7 +69,7 @@ class ElasticaAdapter implements AdapterInterface
      * @param int<0, max> $offset
      * @param int<0, max> $length
      *
-     * @return iterable<array-key, T>
+     * @return iterable<int, Result>
      */
     public function getSlice(int $offset, int $length): iterable
     {

--- a/lib/Adapter/Elastica/Tests/ElasticaAdapterTest.php
+++ b/lib/Adapter/Elastica/Tests/ElasticaAdapterTest.php
@@ -23,9 +23,6 @@ final class ElasticaAdapterTest extends TestCase
      */
     private array $options;
 
-    /**
-     * @var ElasticaAdapter<mixed>
-     */
     private ElasticaAdapter $adapter;
 
     protected function setUp(): void

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -79,12 +79,6 @@ parameters:
 			path: lib/Adapter/Elastica/ElasticaAdapter.php
 
 		-
-			message: '#^Method Pagerfanta\\Elastica\\ElasticaAdapter\:\:getSlice\(\) should return iterable\<\(int\|string\), T\> but returns Elastica\\ResultSet\.$#'
-			identifier: return.type
-			count: 1
-			path: lib/Adapter/Elastica/ElasticaAdapter.php
-
-		-
 			message: '#^Method Pagerfanta\\Solarium\\SolariumAdapter\:\:getNbResults\(\) should return int\<0, max\> but returns int\|null\.$#'
 			identifier: return.type
 			count: 1


### PR DESCRIPTION
The iterator values are always Result as it returns the ResultSet iterator. And keys in a ResultSet are always integers so we can be more precise for the iterable type.