### PR TITLE
Remove phpstan baseline error fixed by the latest phpcr changes

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -67,12 +67,6 @@ parameters:
 			path: lib/Adapter/Doctrine/PHPCRODM/QueryAdapter.php
 
 		-
-			message: '#^Call to an undefined method Iterator\<mixed, PHPCR\\Query\\RowInterface\>\:\:count\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: lib/Adapter/Doctrine/PHPCRODM/QueryAdapter.php
-
-		-
 			message: '#^Method Pagerfanta\\Elastica\\ElasticaAdapter\:\:getNbResults\(\) should return int\<0, max\> but returns int\.$#'
 			identifier: return.type
 			count: 2


### PR DESCRIPTION
`phpcr/phpcr` now has more precise type declaration (actually matching what was previously described in the description of the return type), which allows phpstan to understand that the `count` method exists: https://github.com/phpcr/phpcr/releases/tag/2.1.14